### PR TITLE
Rename upload artifacts folder from test-results to coverage

### DIFF
--- a/src/commands/upload-artifacts.yml
+++ b/src/commands/upload-artifacts.yml
@@ -9,7 +9,7 @@ parameters:
 
 steps:
 - store_test_results:
-    path: << parameters.project-location >>/test-results
+    path: << parameters.project-location >>/coverage
 - store_artifacts:
-    path: << parameters.project-location >>/test-results
+    path: << parameters.project-location >>/coverage
     destination: trl


### PR DESCRIPTION
- [Cypress](https://www.cypress.io/) and [NYC](https://www.cypress.io/) generate the output to a folder called `coverage` instead of `test-results`. If nothing else uses this command yet, we should rename it here so that we can avoid renaming it in the repos themselves.