### PR TITLE
Cache cypress binaries

### DIFF
--- a/src/commands/setup.yml
+++ b/src/commands/setup.yml
@@ -20,3 +20,4 @@ steps:
     paths:
     - "<< parameters.project-location >>/node_modules"
     - "~/.cache/yarn"
+    - "~/.cache/Cypress"


### PR DESCRIPTION
Fixes the following error:
```
The cypress npm package is installed, but the Cypress binary is missing.

We expected the binary to be installed here: /root/.cache/Cypress/3.8.3/Cypress/Cypress

Reasons it may be missing:

- You're caching 'node_modules' but are not caching this path: /root/.cache/Cypress
- You ran 'npm install' at an earlier build step but did not persist: /root/.cache/Cypress

Properly caching the binary will fix this error and avoid downloading and unzipping Cypress.

Alternatively, you can run 'cypress install' to download the binary again.

https://on.cypress.io/not-installed-ci-error
```